### PR TITLE
feat: implement RolePermission entity with DAO, service, and enum update

### DIFF
--- a/src/main/java/org/example/dao/RolePermissionDAO.java
+++ b/src/main/java/org/example/dao/RolePermissionDAO.java
@@ -1,0 +1,113 @@
+package org.example.dao;
+
+import org.example.dao.BaseDAO;
+import org.example.enums.Role;
+import org.example.model.entity.RolePermission;
+import org.example.util.HibernateUtil;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public class RolePermissionDAO extends BaseDAO<RolePermission> {
+
+    public RolePermissionDAO() {
+        super(RolePermission.class);
+    }
+
+    /**
+     * Find RolePermission by Role enum
+     */
+    public Optional<RolePermission> findByRoleName(Role role) {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            Query<RolePermission> query = session.createQuery(
+                    "FROM RolePermission WHERE roleName = :roleName AND deleted = false",
+                    RolePermission.class
+            );
+            query.setParameter("roleName", role);
+            List<RolePermission> result = query.getResultList();
+            return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
+        } catch (Exception e) {
+            System.err.println("Error finding RolePermission by role name: " + e.getMessage());
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Find RolePermission by Role name string (for backward compatibility)
+     */
+    public Optional<RolePermission> findByRoleNameString(String roleName) {
+        try {
+            Role role = Role.valueOf(roleName.toUpperCase());
+            return findByRoleName(role);
+        } catch (IllegalArgumentException e) {
+            System.err.println("Invalid role name: " + roleName);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get all non-deleted RolePermissions
+     */
+    public List<RolePermission> getAllRolePermissions() {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            Query<RolePermission> query = session.createQuery(
+                    "FROM RolePermission WHERE deleted = false ORDER BY roleName",
+                    RolePermission.class
+            );
+            return query.getResultList();
+        } catch (Exception e) {
+            System.err.println("Error getting all role permissions: " + e.getMessage());
+            e.printStackTrace();
+            return List.of(); // Return empty list instead of null
+        }
+    }
+
+    /**
+     * Save or update RolePermission
+     */
+    public boolean saveRolePermission(RolePermission rolePermission) {
+        try {
+            return saveToDB(rolePermission);
+        } catch (Exception e) {
+            System.err.println("Error saving role permission: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Soft delete RolePermission by ID
+     */
+    public void deleteRolePermissionById(Long id) {
+        try {
+            deleteByID(id); // This should use soft delete from BaseDAO
+        } catch (Exception e) {
+            System.err.println("Error deleting role permission with ID " + id + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check if a role already exists
+     */
+    public boolean roleExists(Role role) {
+        return findByRoleName(role).isPresent();
+    }
+
+    /**
+     * Get RolePermission by ID with proper error handling
+     */
+    @Override
+    public Optional<RolePermission> getById(Long id) {
+        try {
+            return super.getById(id);
+        } catch (Exception e) {
+            System.err.println("Error getting role permission by ID " + id + ": " + e.getMessage());
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/example/enums/Role.java
+++ b/src/main/java/org/example/enums/Role.java
@@ -4,5 +4,6 @@ public enum Role {
     ADMIN,
     NURSE,
     DOCTOR,
-    RECEPTION
+    RECEPTION,
+    ACCOUNTANT
 }

--- a/src/main/java/org/example/model/entity/RolePermission.java
+++ b/src/main/java/org/example/model/entity/RolePermission.java
@@ -1,0 +1,73 @@
+package org.example.model.entity;
+
+import jakarta.persistence.*;
+import org.example.enums.Permissions;
+import org.example.enums.Role;
+import org.example.model.base.SoftDeletable;
+
+import java.util.Set;
+
+@Entity
+@Table(name = "role_permission")
+public class RolePermission implements SoftDeletable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_name", nullable = false, unique = true)
+    private Role roleName;
+
+    @ElementCollection(targetClass = Permissions.class, fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "role_permissions", joinColumns = @JoinColumn(name = "role_permission_id"))
+    @Column(name = "permission")
+    private Set<Permissions> permissions;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
+
+    // Constructors
+    public RolePermission() {}
+
+    public RolePermission(Role roleName, Set<Permissions> permissions) {
+        this.roleName = roleName;
+        this.permissions = permissions;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Role getRoleName() {
+        return roleName;
+    }
+
+    public void setRoleName(Role roleName) {
+        this.roleName = roleName;
+    }
+
+    public Set<Permissions> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(Set<Permissions> permissions) {
+        this.permissions = permissions;
+    }
+
+    @Override
+    public boolean isDelete() {
+        return deleted;
+    }
+
+    @Override
+    public void setDelete(boolean deleted) {
+        this.deleted = deleted;
+    }
+}

--- a/src/main/java/org/example/service/RolePermissionService.java
+++ b/src/main/java/org/example/service/RolePermissionService.java
@@ -1,0 +1,21 @@
+package org.example.service;
+
+import org.example.enums.Role;
+import org.example.model.entity.RolePermission;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RolePermissionService {
+
+
+    boolean createRolePermission(RolePermission rolePermission);
+    boolean saveRolePermission(RolePermission rolePermission);
+    Optional<RolePermission> getRolePermissionById(Long id);
+    Optional<RolePermission> findByRoleName(Role role);
+    Optional<RolePermission> getRolePermissionByName(String roleName);
+    List<RolePermission> getAllRolePermissions();
+    boolean updateRolePermission(RolePermission rolePermission);
+    void deleteRolePermission(Long id);
+    boolean roleExists(Role role);
+}


### PR DESCRIPTION
### What does this PR do?
This pull request introduces the `RolePermission` entity and sets up its integration into the backend. It includes the entity model, DAO layer, and service interface. Additionally, it updates the `Role` enum to include a new role.

### Why is it needed?
This change lays the groundwork for a flexible role-based permission system, allowing roles to have specific permissions that can be stored and queried via the database. The new role added to the enum is needed to support upcoming functionality.

### What was changed?
- Added `RolePermission` entity class
- Implemented DAO classes for `RolePermission`
- Defined a service interface for `RolePermission`
- Updated the `Role` enum to include a new role

### How can it be tested?
- Ensure the application compiles and runs
- Verify `RolePermission` entries can be created, saved, and retrieved using the DAO
- Check that the new role appears and is usable in logic that relies on the `Role` enum

### Related issues
Closes #<insert-issue-id-if-any>
