### PR TITLE
feat: implement permission-based access control with annotation and interceptor

### DIFF
--- a/src/main/java/org/example/annotation/RequiresPermission.java
+++ b/src/main/java/org/example/annotation/RequiresPermission.java
@@ -1,0 +1,16 @@
+package org.example.annotation;
+
+import jakarta.interceptor.InterceptorBinding;
+import org.example.enums.Permissions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface RequiresPermission {
+    Permissions value();
+}

--- a/src/main/java/org/example/bean/RolePermissionPickListView.java
+++ b/src/main/java/org/example/bean/RolePermissionPickListView.java
@@ -1,0 +1,163 @@
+package org.example.bean;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.example.annotation.RequiresPermission;
+import org.example.enums.Permissions;
+import org.example.enums.Role;
+import org.example.model.entity.RolePermission;
+import org.example.service.RolePermissionService;
+import org.primefaces.event.SelectEvent;
+import org.primefaces.event.TransferEvent;
+import org.primefaces.event.UnselectEvent;
+import org.primefaces.model.DualListModel;
+
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import java.io.Serializable;
+import java.security.Permission;
+import java.util.*;
+
+@Named
+@RequestScoped
+public class RolePermissionPickListView implements Serializable {
+
+    private DualListModel<Permissions> permissions;
+
+    @Inject
+    private RolePermissionService rolePermissionService;
+
+    private Role selectedRole;
+
+    @PostConstruct
+    public void init() {
+        List<Permissions> allPermissions = Arrays.asList(Permissions.values());
+        permissions = new DualListModel<>(allPermissions, new ArrayList<>());
+        List<Permission> source = new ArrayList<>(); // Available permissions
+        List<Permission> target = new ArrayList<>(); // Assigned permissions
+
+    }
+
+    // Load existing permissions for a role
+    public void loadRolePermissions() {
+        if (selectedRole != null) {
+            // Load existing permissions for the selected role
+            RolePermission existingRolePermission = rolePermissionService.findByRoleName(selectedRole).orElse(null);
+
+            List<Permissions> allPermissions = Arrays.asList(Permissions.values());
+            List<Permissions> assignedPermissions = new ArrayList<>();
+            List<Permissions> availablePermissions = new ArrayList<>(allPermissions);
+
+            if (existingRolePermission != null && existingRolePermission.getPermissions() != null) {
+                assignedPermissions.addAll(existingRolePermission.getPermissions());
+                availablePermissions.removeAll(assignedPermissions);
+            }
+
+            permissions = new DualListModel<>(availablePermissions, assignedPermissions);
+        }
+    }
+
+    // Ajax event methods
+    @RequiresPermission(Permissions.CREATE_PERMISSION)
+    public void onTransfer(TransferEvent event) {
+        StringBuilder builder = new StringBuilder("Transferred: <br/>");
+        for (Object item : event.getItems()) {
+            Permissions perm = (Permissions) item;
+            builder.append(perm.name()).append("<br />");
+        }
+        FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage(FacesMessage.SEVERITY_INFO, "Permissions Transferred", builder.toString()));
+    }
+
+    public void onSelect(SelectEvent<Permissions> event) {
+        FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage(FacesMessage.SEVERITY_INFO, "Selected", event.getObject().name()));
+    }
+
+    public void onUnselect(UnselectEvent<Permissions> event) {
+        FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage(FacesMessage.SEVERITY_INFO, "Unselected", event.getObject().name()));
+    }
+
+    public void onReorder() {
+        FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage(FacesMessage.SEVERITY_INFO, "List Reordered", null));
+    }
+
+    // Business method for saving the role
+    @RequiresPermission(Permissions.CREATE_PERMISSION)
+    public void saveRoleWithPermissions() {
+        if (selectedRole == null) {
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "Please select a role first."));
+            return;
+        }
+
+        try {
+            Optional<RolePermission> existingOpt = rolePermissionService.findByRoleName(selectedRole);
+            RolePermission rolePermission;
+
+            if (existingOpt.isPresent()) {
+                // ✅ Update the existing managed entity
+                rolePermission = existingOpt.get();
+                rolePermission.setPermissions(new HashSet<>(permissions.getTarget()));
+
+            } else {
+                // ✅ Create new only if doesn't exist
+                rolePermission = new RolePermission();
+                rolePermission.setRoleName(selectedRole);
+                rolePermission.setPermissions(new HashSet<>(permissions.getTarget()));
+
+            }
+
+            boolean saved = rolePermissionService.saveRolePermission(rolePermission);
+
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(saved ? FacesMessage.SEVERITY_INFO : FacesMessage.SEVERITY_ERROR,
+                            saved ? "Success" : "Failure",
+                            saved ? "Role permissions saved successfully!" : "Failed to save role permissions."));
+
+        } catch (Exception e) {
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "An error occurred while saving: " + e.getMessage()));
+        }
+    }
+
+
+    // Reset form
+    public void resetForm() {
+        selectedRole = null;
+        List<Permissions> allPermissions = Arrays.asList(Permissions.values());
+        permissions = new DualListModel<>(allPermissions, new ArrayList<>());
+    }
+
+    // Utility methods
+    public List<Permissions> getAllPermissions() {
+        return Arrays.asList(Permissions.values());
+    }
+
+    public Role[] getAllRoles() {
+        return Role.values();
+    }
+
+    // Getters and Setters
+    public DualListModel<Permissions> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(DualListModel<Permissions> permissions) {
+        this.permissions = permissions;
+    }
+
+    public Role getSelectedRole() {
+        return selectedRole;
+    }
+
+    public void setSelectedRole(Role selectedRole) {
+        this.selectedRole = selectedRole;
+        // Auto-load permissions when role is selected
+        loadRolePermissions();
+    }
+}

--- a/src/main/java/org/example/interceptor/RequiresPermissionInterceptor.java
+++ b/src/main/java/org/example/interceptor/RequiresPermissionInterceptor.java
@@ -1,0 +1,41 @@
+package org.example.interceptor;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import org.example.annotation.RequiresPermission;
+import org.example.enums.Permissions;  
+import org.example.session.UserSession;
+
+@Interceptor
+@RequiresPermission(Permissions.NONE)
+@Priority(Interceptor.Priority.APPLICATION)
+public class RequiresPermissionInterceptor {
+
+    @Inject
+    private UserSession userSession;
+
+    @AroundInvoke
+    public Object checkPermission(InvocationContext ctx) throws Exception {
+        // Get @RequiresPermission from method first
+        RequiresPermission annotation = ctx.getMethod().getAnnotation(RequiresPermission.class);
+
+        // If not found on method, check on class
+        if (annotation == null) {
+            annotation = ctx.getTarget().getClass().getAnnotation(RequiresPermission.class);
+        }
+
+
+        if (annotation != null) {
+            Permissions required = annotation.value();  // Get required permission
+
+            if (userSession == null || !userSession.hasPermission(required)) {
+                throw new SecurityException("Access denied: missing permission " + required);
+            }
+        }
+
+        return ctx.proceed();
+    }
+}

--- a/src/main/java/org/example/service/Impl/RolePermissionServiceImpl.java
+++ b/src/main/java/org/example/service/Impl/RolePermissionServiceImpl.java
@@ -1,0 +1,191 @@
+package org.example.service.impl;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.example.dao.RolePermissionDAO;
+import org.example.enums.Role;
+import org.example.model.entity.RolePermission;
+import org.example.service.Impl.BaseService;
+import org.example.service.RolePermissionService;
+
+
+import java.util.List;
+import java.util.Optional;
+
+@ApplicationScoped
+public class RolePermissionServiceImpl extends BaseService implements RolePermissionService {
+
+    @Inject
+    private RolePermissionDAO rolePermissionDAO;
+
+    @Override
+    public boolean createRolePermission(RolePermission rolePermission) {
+        try {
+            // Validate input
+            validateRolePermission(rolePermission);
+
+            // Check if role already exists
+            if (roleExists(rolePermission.getRoleName())) {
+                System.err.println("Role already exists: " + rolePermission.getRoleName());
+                return false;
+            }
+
+            return rolePermissionDAO.saveRolePermission(rolePermission);
+        } catch (Exception e) {
+            System.err.println("Error creating role permission: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    public boolean saveRolePermission(RolePermission rolePermission) {
+        try {
+            validateRolePermission(rolePermission);
+
+            // For updates, check if ID exists and it's the same role or role doesn't exist elsewhere
+            if (rolePermission.getId() != null) {
+                Optional<RolePermission> existing = rolePermissionDAO.findByRoleName(rolePermission.getRoleName());
+                if (existing.isPresent() && !existing.get().getId().equals(rolePermission.getId())) {
+                    System.err.println("Role already exists with different ID: " + rolePermission.getRoleName());
+                    return false;
+                }
+            } else {
+                // For new entries, check if role already exists
+                if (roleExists(rolePermission.getRoleName())) {
+                    System.err.println("Role already exists: " + rolePermission.getRoleName());
+                    return false;
+                }
+            }
+
+            return rolePermissionDAO.saveRolePermission(rolePermission);
+        } catch (Exception e) {
+            System.err.println("Error saving role permission: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    public Optional<RolePermission> getRolePermissionById(Long id) {
+        try {
+            isIdValid(id);
+            return rolePermissionDAO.getById(id);
+        } catch (Exception e) {
+            System.err.println("Error getting role permission by ID: " + e.getMessage());
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<RolePermission> findByRoleName(Role role) {
+        try {
+            if (role == null) {
+                throw new IllegalArgumentException("Role cannot be null");
+            }
+            return rolePermissionDAO.findByRoleName(role);
+        } catch (Exception e) {
+            System.err.println("Error finding role permission by role name: " + e.getMessage());
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<RolePermission> getRolePermissionByName(String roleName) {
+        try {
+            isNonNullableNameValid(roleName);
+            return rolePermissionDAO.findByRoleNameString(roleName);
+        } catch (Exception e) {
+            System.err.println("Error getting role permission by name: " + e.getMessage());
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<RolePermission> getAllRolePermissions() {
+        try {
+            return rolePermissionDAO.getAllRolePermissions();
+        } catch (Exception e) {
+            System.err.println("Error getting all role permissions: " + e.getMessage());
+            e.printStackTrace();
+            return List.of();
+        }
+    }
+
+    @Override
+    public boolean updateRolePermission(RolePermission rolePermission) {
+        try {
+            if (rolePermission.getId() == null) {
+                throw new IllegalArgumentException("ID cannot be null for update operation");
+            }
+
+            isIdValid(rolePermission.getId());
+            validateRolePermission(rolePermission);
+
+            // Check if the role permission exists
+            Optional<RolePermission> existing = rolePermissionDAO.getById(rolePermission.getId());
+            if (existing.isEmpty()) {
+                System.err.println("Role permission not found for update: " + rolePermission.getId());
+                return false;
+            }
+
+            // Check if changing to a role that already exists elsewhere
+            Optional<RolePermission> existingByRole = rolePermissionDAO.findByRoleName(rolePermission.getRoleName());
+            if (existingByRole.isPresent() && !existingByRole.get().getId().equals(rolePermission.getId())) {
+                System.err.println("Cannot update: Role already exists with different ID: " + rolePermission.getRoleName());
+                return false;
+            }
+
+            return rolePermissionDAO.saveRolePermission(rolePermission);
+        } catch (Exception e) {
+            System.err.println("Error updating role permission: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    public void deleteRolePermission(Long id) {
+        try {
+            isIdValid(id);
+            rolePermissionDAO.deleteRolePermissionById(id);
+        } catch (Exception e) {
+            System.err.println("Error deleting role permission: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean roleExists(Role role) {
+        try {
+            if (role == null) {
+                return false;
+            }
+            return rolePermissionDAO.roleExists(role);
+        } catch (Exception e) {
+            System.err.println("Error checking if role exists: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Private method to validate RolePermission input
+     */
+    private void validateRolePermission(RolePermission rolePermission) {
+        if (rolePermission == null) {
+            throw new IllegalArgumentException("RolePermission cannot be null");
+        }
+
+        if (rolePermission.getRoleName() == null) {
+            throw new IllegalArgumentException("Role name cannot be null");
+        }
+
+        if (rolePermission.getPermissions() == null || rolePermission.getPermissions().isEmpty()) {
+            throw new IllegalArgumentException("Permissions cannot be null or empty");
+        }
+    }
+}

--- a/src/main/webapp/pages/admin/RolePermissionPickList.xhtml
+++ b/src/main/webapp/pages/admin/RolePermissionPickList.xhtml
@@ -1,0 +1,92 @@
+<ui:composition template="/pages/templates/layout.xhtml"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:pt="http://java.sun.com/jsf/core">
+
+    <ui:define name="content">
+        <div>
+            <h:form>
+                <h:panelGrid columns="1" styleClass="card">
+                    <h:outputLabel value="Role:" for="roleSelectMenu"/>
+
+                    <!-- Role Selection Menu Component -->
+                    <p:selectOneMenu id="roleSelectMenu"
+                                     value="#{rolePermissionPickListView.selectedRole}"
+                                     required="true"
+                                     requiredMessage="Please select a role"
+                                     styleClass="role-select-menu">
+
+                        <!-- Default empty option -->
+                        <f:selectItem itemLabel="-- Select a Role --"
+                                      itemValue="#{null}"
+                                      noSelectionOption="true"/>
+
+                        <!-- Dynamic role options from enum -->
+                        <f:selectItems value="#{rolePermissionPickListView.allRoles}"
+                                       var="role"
+                                       itemLabel="#{role.name()}"
+                                       itemValue="#{role}"/>
+
+                        <!-- AJAX event to load permissions when role is selected -->
+                        <p:ajax event="change"
+                                listener="#{rolePermissionPickListView.loadRolePermissions}"
+                                update="permissionPickList msg"
+                                global="false"/>
+
+                        <!-- Optional: Add a converter if needed -->
+<!--                        <f:converter converterId="roleConverter"/>-->
+
+                    </p:selectOneMenu>
+
+
+                    <p:pickList id="permissionPickList"
+                                value="#{rolePermissionPickListView.permissions}"
+                                var="perm"
+                                itemValue="#{perm}"
+                                itemLabel="#{perm.name()}"
+                                showSourceControls="true"
+                                showTargetControls="true"
+                                showCheckbox="true"
+                                showSourceFilter="true"
+                                showTargetFilter="true"
+                                sourceFilterPlaceholder="Filter available"
+                                targetFilterPlaceholder="Filter assigned"
+                                converter="permissionConverter"
+                                responsive="true">
+
+                        <f:facet name="sourceCaption">Available Permissions</f:facet>
+                        <f:facet name="targetCaption">Assigned Permissions</f:facet>
+
+                        <p:ajax event="transfer"
+                                listener="#{rolePermissionPickListView.onTransfer}"
+                                update="msg"/>
+                        <p:ajax event="select"
+                                listener="#{rolePermissionPickListView.onSelect}"
+                                update="msg"/>
+                        <p:ajax event="unselect"
+                                listener="#{rolePermissionPickListView.onUnselect}"
+                                update="msg"/>
+                        <p:ajax event="reorder"
+                                listener="#{rolePermissionPickListView.onReorder}"
+                                update="msg"/>
+
+                        <p:column>
+                            <h:outputText value="#{perm.name()}"/>
+                        </p:column>
+                    </p:pickList>
+
+                    <p:commandButton
+                            value="Save Permissions"
+                            action="#{rolePermissionPickListView.saveRoleWithPermissions}"
+                            ajax="false"
+                            update="@form msg"/>
+
+                    <p:messages id="msg" showDetail="true" closable="true"/>
+                </h:panelGrid>
+            </h:form>
+        </div>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
### What does this PR do?
This pull request introduces a permission-based access control mechanism using custom annotations and interceptors. It also includes the necessary backing bean and service implementation for handling role-permission logic.

### Why is it needed?
This setup enables declarative permission enforcement across the application using annotations, reducing boilerplate and improving security. It allows for fine-grained control over who can access which functionality based on roles and permissions.

### What was changed?
- Added `RolePermissionBean` to manage UI-level interactions
- Created custom `@RequiresPermission` annotation to mark secured methods
- Implemented `RequiresPermissionInterceptor` to enforce permission checks at runtime
- Completed the implementation of the `RolePermissionService` to support permission retrieval and validation

### How can it be tested?
1. Annotate a method with `@RequiresPermission(Permissions.SOME_ACTION)`
2. Login with a user lacking that permission — access should be denied
3. Login with a user who has that permission — access should be granted
4. Verify permission resolution works through the service layer


